### PR TITLE
Fix typos

### DIFF
--- a/src/js/swipe.js
+++ b/src/js/swipe.js
@@ -114,8 +114,8 @@ export class Swipe
             result.offsetX = Math.round(touch.clientX)
             result.offsetY = Math.round(touch.clientY)
         } else {
-            result.offsetX = Math.round(e.clientX)
-            result.offsetY = Math.round(e.clientY)
+            result.offsetX = Math.round(event.clientX)
+            result.offsetY = Math.round(event.clientY)
         }
 
         return result


### PR DESCRIPTION
Hi!

While everything seems to work fine I get an error, at least in Firefox while using the devtools and the touch simulator.
I believe there are some typos.

Fixes error:

```
Uncaught ReferenceError: e is not defined
    getTouches swipe.js:117
    handleTouchStart swipe.js:130
    eventListener swipe.js:92
    Swipe swipe.js:63
```